### PR TITLE
fix(LlmExecutor): Use proper system messages and track token usage

### DIFF
--- a/spring-ai-agents-starter/src/main/java/com/springai/agents/autoconfigure/AgentsAutoConfiguration.java
+++ b/spring-ai-agents-starter/src/main/java/com/springai/agents/autoconfigure/AgentsAutoConfiguration.java
@@ -125,15 +125,27 @@ public class AgentsAutoConfiguration {
 
     // ── Workflow Executors ──────────────────────────────────────────────
 
-    @Bean
-    @ConditionalOnMissingBean
+    @Bean(destroyMethod = "shutdown")
+    @ConditionalOnMissingBean(name = "workflowThreadPool")
     @ConditionalOnProperty(name = "spring.ai.agents.reactive", havingValue = "false", matchIfMissing = true)
-    public WorkflowExecutor workflowExecutor(NodeExecutorRegistry executorRegistry, AgentsProperties properties,
-                                             Optional<ApplicationEventPublisher> eventPublisher) {
+    public ExecutorService workflowThreadPool(AgentsProperties properties) {
         ExecutorService threadPool = properties.getParallelThreads() > 0
                 ? Executors.newFixedThreadPool(properties.getParallelThreads())
                 : Executors.newCachedThreadPool();
-        return new WorkflowExecutor(executorRegistry, threadPool, eventPublisher.orElse(null));
+        log.info("Created workflow thread pool: {}", 
+                properties.getParallelThreads() > 0 
+                    ? "fixed(" + properties.getParallelThreads() + ")" 
+                    : "cached");
+        return threadPool;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(name = "spring.ai.agents.reactive", havingValue = "false", matchIfMissing = true)
+    public WorkflowExecutor workflowExecutor(NodeExecutorRegistry executorRegistry, 
+                                             ExecutorService workflowThreadPool,
+                                             Optional<ApplicationEventPublisher> eventPublisher) {
+        return new WorkflowExecutor(executorRegistry, workflowThreadPool, eventPublisher.orElse(null));
     }
 
     @Bean

--- a/spring-ai-agents-starter/src/main/java/com/springai/agents/autoconfigure/AgentsAutoConfiguration.java
+++ b/spring-ai-agents-starter/src/main/java/com/springai/agents/autoconfigure/AgentsAutoConfiguration.java
@@ -126,7 +126,7 @@ public class AgentsAutoConfiguration {
     // ── Workflow Executors ──────────────────────────────────────────────
 
     @Bean(destroyMethod = "shutdown")
-    @ConditionalOnMissingBean(name = "workflowThreadPool")
+    @ConditionalOnMissingBean({WorkflowExecutor.class, ExecutorService.class})
     @ConditionalOnProperty(name = "spring.ai.agents.reactive", havingValue = "false", matchIfMissing = true)
     public ExecutorService workflowThreadPool(AgentsProperties properties) {
         ExecutorService threadPool = properties.getParallelThreads() > 0

--- a/spring-ai-agents-starter/src/main/java/com/springai/agents/executor/LlmExecutor.java
+++ b/spring-ai-agents-starter/src/main/java/com/springai/agents/executor/LlmExecutor.java
@@ -3,9 +3,15 @@ package com.springai.agents.executor;
 import com.springai.agents.node.LlmNode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
 import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static reactor.core.scheduler.Schedulers.boundedElastic;
 
@@ -14,7 +20,9 @@ import static reactor.core.scheduler.Schedulers.boundedElastic;
  * <p>
  * The prompt template is interpolated with {@code {nodeId}} placeholders replaced by
  * dependency outputs and {@code {input}} replaced by the raw user input. If the node
- * has a {@code systemPrompt}, it is prepended to the final prompt.
+ * has a {@code systemPrompt}, it is sent as a proper system message to the LLM.
+ * <p>
+ * Usage metadata (input/output tokens) is logged when available.
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -24,9 +32,25 @@ public class LlmExecutor implements NodeExecutor<LlmNode>, ReactiveNodeExecutor<
 
     @Override
     public Object execute(LlmNode node, NodeContext context) {
-        String processedPrompt = buildPrompt(node, context);
-        log.debug("LlmNode '{}': calling LLM with prompt length={}", node.getId(), processedPrompt.length());
-        return chatModel.call(new Prompt(processedPrompt)).getResult().getOutput().getText();
+        Prompt prompt = buildPrompt(node, context);
+        log.debug("LlmNode '{}': calling LLM with {} message(s)", node.getId(), prompt.getInstructions().size());
+        
+        ChatResponse response = chatModel.call(prompt);
+        
+        // Log usage metadata if available
+        if (response.getMetadata() != null && response.getMetadata().getUsage() != null) {
+            var usage = response.getMetadata().getUsage();
+            log.debug("LlmNode '{}': tokens used — input={}, output={}, total={}",
+                    node.getId(),
+                    usage.getPromptTokens(),
+                    usage.getCompletionTokens(),
+                    usage.getTotalTokens());
+            
+            // Store usage in execution context for downstream access
+            context.getExecutionContext().put(node.getId() + "_usage", usage);
+        }
+        
+        return response.getResult().getOutput().getText();
     }
 
     @Override
@@ -40,13 +64,24 @@ public class LlmExecutor implements NodeExecutor<LlmNode>, ReactiveNodeExecutor<
         return LlmNode.class;
     }
 
-    private String buildPrompt(LlmNode node, NodeContext context) {
-        String prompt = PromptInterpolator.interpolate(
+    /**
+     * Build a proper Prompt with system and user messages.
+     * Uses Spring AI's message types instead of string concatenation.
+     */
+    private Prompt buildPrompt(LlmNode node, NodeContext context) {
+        String userPrompt = PromptInterpolator.interpolate(
                 node.getPromptTemplate(), context.getDependencyResults(), context.getExecutionContext());
 
+        List<org.springframework.ai.chat.messages.Message> messages = new ArrayList<>();
+        
+        // Add system message if present
         if (node.getSystemPrompt() != null && !node.getSystemPrompt().isBlank()) {
-            prompt = node.getSystemPrompt() + "\n\n" + prompt;
+            messages.add(new SystemMessage(node.getSystemPrompt()));
         }
-        return prompt;
+        
+        // Add user message
+        messages.add(new UserMessage(userPrompt));
+        
+        return new Prompt(messages);
     }
 }

--- a/spring-ai-agents-starter/src/main/java/com/springai/agents/executor/LlmExecutor.java
+++ b/spring-ai-agents-starter/src/main/java/com/springai/agents/executor/LlmExecutor.java
@@ -38,16 +38,25 @@ public class LlmExecutor implements NodeExecutor<LlmNode>, ReactiveNodeExecutor<
         ChatResponse response = chatModel.call(prompt);
         
         // Log usage metadata if available
-        if (response.getMetadata() != null && response.getMetadata().getUsage() != null) {
-            var usage = response.getMetadata().getUsage();
+        var metadata = response.getMetadata();
+        if (metadata != null && metadata.getUsage() != null) {
+            var usage = metadata.getUsage();
             log.debug("LlmNode '{}': tokens used — input={}, output={}, total={}",
                     node.getId(),
                     usage.getPromptTokens(),
                     usage.getCompletionTokens(),
                     usage.getTotalTokens());
             
-            // Store usage in execution context for downstream access
-            context.getExecutionContext().put(node.getId() + "_usage", usage);
+            // Store usage in execution context for downstream access, if possible
+            try {
+                context.getExecutionContext().put(node.getId() + "_usage", usage);
+            } catch (UnsupportedOperationException ex) {
+                // Execution context may be backed by an unmodifiable map (e.g. Map.of()); skip storing usage
+                log.trace("LlmNode '{}': execution context is unmodifiable; skipping usage storage", node.getId());
+            } catch (Exception ex) {
+                // Avoid failing node execution due to unexpected context issues
+                log.warn("LlmNode '{}': failed to store usage metadata in execution context", node.getId(), ex);
+            }
         }
         
         return response.getResult().getOutput().getText();

--- a/spring-ai-agents-starter/src/test/java/com/springai/agents/executor/LlmExecutorTest.java
+++ b/spring-ai-agents-starter/src/test/java/com/springai/agents/executor/LlmExecutorTest.java
@@ -6,12 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.metadata.Usage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,6 +28,26 @@ class LlmExecutorTest {
         ChatModel chatModel = mock(ChatModel.class);
         Generation generation = new Generation(new AssistantMessage(response));
         ChatResponse chatResponse = new ChatResponse(List.of(generation));
+        when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse);
+        return chatModel;
+    }
+
+    private ChatModel mockChatModelWithUsage(String response, long promptTokens, long completionTokens) {
+        ChatModel chatModel = mock(ChatModel.class);
+        Generation generation = new Generation(new AssistantMessage(response));
+        
+        Usage usage = mock(Usage.class);
+        when(usage.getPromptTokens()).thenReturn(promptTokens);
+        when(usage.getCompletionTokens()).thenReturn(completionTokens);
+        when(usage.getTotalTokens()).thenReturn(promptTokens + completionTokens);
+        
+        ChatResponseMetadata metadata = mock(ChatResponseMetadata.class);
+        when(metadata.getUsage()).thenReturn(usage);
+        
+        ChatResponse chatResponse = mock(ChatResponse.class);
+        when(chatResponse.getResult()).thenReturn(generation);
+        when(chatResponse.getMetadata()).thenReturn(metadata);
+        
         when(chatModel.call(any(Prompt.class))).thenReturn(chatResponse);
         return chatModel;
     }
@@ -127,9 +148,58 @@ class LlmExecutorTest {
 
         var captor = org.mockito.ArgumentCaptor.forClass(Prompt.class);
         verify(chatModel).call(captor.capture());
-        String sentPrompt = captor.getValue().getContents();
-        assertTrue(sentPrompt.contains("first-result"));
-        assertTrue(sentPrompt.contains("second-result"));
+        
+        // Get the user message text from instructions
+        List<Message> messages = captor.getValue().getInstructions();
+        assertEquals(1, messages.size());
+        String userMessageText = messages.get(0).getText();
+        assertTrue(userMessageText.contains("first-result"));
+        assertTrue(userMessageText.contains("second-result"));
+    }
+
+    @Test
+    @DisplayName("extracts and stores usage metadata when available")
+    void extractsUsageMetadata() {
+        ChatModel chatModel = mockChatModelWithUsage("response", 100, 50);
+        var executor = new LlmExecutor(chatModel);
+        var node = LlmNode.builder()
+                .id("analyze")
+                .promptTemplate("Test prompt")
+                .build();
+        var executionContext = new ConcurrentHashMap<String, Object>();
+        var ctx = NodeContext.builder()
+                .resolvedInput("")
+                .executionContext(executionContext)
+                .build();
+
+        executor.execute(node, ctx);
+
+        // Verify usage was stored in execution context
+        assertTrue(executionContext.containsKey("analyze_usage"), "Usage should be stored in context");
+        Usage storedUsage = (Usage) executionContext.get("analyze_usage");
+        assertEquals(100L, storedUsage.getPromptTokens());
+        assertEquals(50L, storedUsage.getCompletionTokens());
+        assertEquals(150L, storedUsage.getTotalTokens());
+    }
+
+    @Test
+    @DisplayName("handles unmodifiable execution context gracefully")
+    void handlesUnmodifiableContext() {
+        ChatModel chatModel = mockChatModelWithUsage("response", 100, 50);
+        var executor = new LlmExecutor(chatModel);
+        var node = LlmNode.builder()
+                .id("analyze")
+                .promptTemplate("Test prompt")
+                .build();
+        // Use unmodifiable map - should not throw
+        var ctx = NodeContext.builder()
+                .resolvedInput("")
+                .executionContext(Map.of())
+                .build();
+
+        // Should not throw despite unmodifiable map
+        Object result = executor.execute(node, ctx);
+        assertEquals("response", result);
     }
 
     @Test

--- a/spring-ai-agents-starter/src/test/java/com/springai/agents/executor/LlmExecutorTest.java
+++ b/spring-ai-agents-starter/src/test/java/com/springai/agents/executor/LlmExecutorTest.java
@@ -4,13 +4,17 @@ import com.springai.agents.node.LlmNode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,7 +42,7 @@ class LlmExecutorTest {
                 .build();
         var ctx = NodeContext.builder()
                 .resolvedInput("user data")
-                .executionContext(Map.of("currentInput", "user data"))
+                .executionContext(new ConcurrentHashMap<>(Map.of("currentInput", "user data")))
                 .build();
 
         Object result = executor.execute(node, ctx);
@@ -48,8 +52,8 @@ class LlmExecutorTest {
     }
 
     @Test
-    @DisplayName("prepends system prompt when set")
-    void systemPrompt() {
+    @DisplayName("sends system prompt as proper SystemMessage")
+    void systemPromptAsMessage() {
         ChatModel chatModel = mockChatModel("response");
         var executor = new LlmExecutor(chatModel);
         var node = LlmNode.builder()
@@ -59,16 +63,48 @@ class LlmExecutorTest {
                 .build();
         var ctx = NodeContext.builder()
                 .resolvedInput("")
-                .executionContext(Map.of("currentInput", "test"))
+                .executionContext(new ConcurrentHashMap<>(Map.of("currentInput", "test")))
                 .build();
 
         executor.execute(node, ctx);
 
         var captor = org.mockito.ArgumentCaptor.forClass(Prompt.class);
         verify(chatModel).call(captor.capture());
-        String sentPrompt = captor.getValue().getContents();
-        assertTrue(sentPrompt.contains("You are a helpful assistant."));
-        assertTrue(sentPrompt.contains("Query: test"));
+        
+        List<Message> messages = captor.getValue().getInstructions();
+        assertEquals(2, messages.size(), "Should have system + user messages");
+        
+        // First message should be system
+        assertEquals(MessageType.SYSTEM, messages.get(0).getMessageType());
+        assertEquals("You are a helpful assistant.", messages.get(0).getText());
+        
+        // Second message should be user
+        assertEquals(MessageType.USER, messages.get(1).getMessageType());
+        assertTrue(messages.get(1).getText().contains("Query:"));
+    }
+
+    @Test
+    @DisplayName("sends only user message when no system prompt")
+    void noSystemPrompt() {
+        ChatModel chatModel = mockChatModel("response");
+        var executor = new LlmExecutor(chatModel);
+        var node = LlmNode.builder()
+                .id("node")
+                .promptTemplate("Query: {input}")
+                .build();
+        var ctx = NodeContext.builder()
+                .resolvedInput("")
+                .executionContext(new ConcurrentHashMap<>(Map.of("currentInput", "test")))
+                .build();
+
+        executor.execute(node, ctx);
+
+        var captor = org.mockito.ArgumentCaptor.forClass(Prompt.class);
+        verify(chatModel).call(captor.capture());
+        
+        List<Message> messages = captor.getValue().getInstructions();
+        assertEquals(1, messages.size(), "Should have only user message");
+        assertEquals(MessageType.USER, messages.get(0).getMessageType());
     }
 
     @Test
@@ -84,7 +120,7 @@ class LlmExecutorTest {
                 .resolvedInput("")
                 .dependencyResult("a", "first-result")
                 .dependencyResult("b", "second-result")
-                .executionContext(Map.of())
+                .executionContext(new ConcurrentHashMap<>())
                 .build();
 
         executor.execute(node, ctx);
@@ -102,4 +138,3 @@ class LlmExecutorTest {
         assertEquals(LlmNode.class, new LlmExecutor(mockChatModel("")).getNodeType());
     }
 }
-


### PR DESCRIPTION
## Summary

This PR improves the LlmExecutor with proper Spring AI message handling and better observability.

## Changes

### 1. Proper System Message Handling
**Before:** System prompts were prepended to the user message as a string:
```java
prompt = node.getSystemPrompt() + "\n\n" + prompt;
```

**After:** Uses Spring AI's proper message types:
```java
messages.add(new SystemMessage(node.getSystemPrompt()));
messages.add(new UserMessage(userPrompt));
```

This ensures LLMs that distinguish between system and user messages (Claude, GPT-4, etc.) handle prompts correctly.

### 2. Token Usage Tracking
Now extracts and logs token usage from ChatResponse metadata:
```
LlmNode 'analyze': tokens used — input=150, output=89, total=239
```
Usage is also stored in the execution context for downstream access.

### 3. Thread Pool Lifecycle Management
Extracted the thread pool to a separate bean with `destroyMethod = "shutdown"` to prevent resource leaks on application shutdown.

## Testing
Updated LlmExecutorTest to verify:
- System prompts are sent as SystemMessage type
- User prompts are sent as UserMessage type
- Correct message count (2 with system, 1 without)